### PR TITLE
Remove Kubernetes dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ ENV USER_UID=10001
 
 ENV HZ_VERSION 3.12
 
-ARG HZ_KUBE_VERSION=1.3.1
 ARG HZ_MAVEN_DIR=${HZ_VERSION}
 ARG REPOSITORY_URL=https://repository.hazelcast.com
 ARG NETTY_VERSION=4.1.32.Final
@@ -76,7 +75,6 @@ USER $USER_UID
 RUN cd mvnw && \
     chmod +x mvnw && \
     ./mvnw -f dependency-copy.xml \
-    -Dhazelcast-kubernetes-version=${HZ_KUBE_VERSION} \
     -Dnetty.version=${NETTY_VERSION} \
     -Dnetty-tcnative.version=${NETTY_TCNATIVE_VERSION} \
     dependency:copy-dependencies && \

--- a/mvnw/dependency-copy.xml
+++ b/mvnw/dependency-copy.xml
@@ -9,17 +9,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.hazelcast</groupId>
-      <artifactId>hazelcast-kubernetes</artifactId>
-      <version>${hazelcast-kubernetes-version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.hazelcast</groupId>
-          <artifactId>hazelcast</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
       <version>${netty-tcnative.version}</version>


### PR DESCRIPTION
Since 3.12, `hazelcast-kubernetes` is already included in `hazlecast-all`.

Port from https://github.com/hazelcast/hazelcast-docker/pull/112.